### PR TITLE
adding DAOAvatar Permissions

### DIFF
--- a/packages/dev-scripts/src/development.js
+++ b/packages/dev-scripts/src/development.js
@@ -8,6 +8,27 @@ const hre = require("hardhat");
 async function main() {
   console.log("Executing develoment scripts");
   // Build develop-related actions here using hre.deployments
+  await addDAOAvatarPermissions();
+}
+
+async function addDAOAvatarPermissions() {
+  const DAOAvatar = await hre.deployments.get("DAOAvatar");
+
+  const PermissionRegistry = await hre.artifacts.require("PermissionRegistry");
+  const permissionRegistryDeployed = await hre.deployments.get(
+    "PermissionRegistry"
+  );
+  const permissionRegistry = await PermissionRegistry.at(
+    permissionRegistryDeployed.address
+  );
+
+  await permissionRegistry.setETHPermission(
+    DAOAvatar.address,
+    "0x0000000000000000000000000000000000000000",
+    "0x00000000",
+    0,
+    true
+    );
 }
 
 main().catch((error) => {


### PR DESCRIPTION
Adding DAOAvatar Permissions for localhost environment on `development.js`

@MiltonTulli i had to remove the line 29 of `dev.sh`: `cp -r ../types ../../dxdao-contracts/types`. It was throwing me an error because there was no folder types. I removed it and it worked fine, but i didn't commit it because i guess it should be there. 
Let me know if you want me to remove it on this branch. 